### PR TITLE
removed authconfig package definition

### DIFF
--- a/data/os/RedHat/6.yaml
+++ b/data/os/RedHat/6.yaml
@@ -4,7 +4,6 @@ sssd::service_dependencies:
  - 'messagebus'
 
 sssd::extra_packages:
-  - 'authconfig'
   - 'oddjob-mkhomedir'
 
 sssd::manage_oddjobd: true


### PR DESCRIPTION
we manage the `authconfig` package elsewhere in puppet